### PR TITLE
Update HtmlHelperExtensions.cs to include useful URL generation methods

### DIFF
--- a/KalikoCMS.Mvc/Extensions/HtmlHelperExtensions.cs
+++ b/KalikoCMS.Mvc/Extensions/HtmlHelperExtensions.cs
@@ -122,6 +122,18 @@ namespace KalikoCMS.Mvc.Extensions {
                 stringBuilder.Append("</li>");
             }
         }
+        
+        public static string StartPageUrl(this HtmlHelper helper)
+        {
+            var startPageId = SiteSettings.Instance.StartPageId;
+            return GetUrlForPage(helper, startPageId);
+        }
+
+        public static string GetUrlForPage(this HtmlHelper helper, Guid pageId)
+        {
+            var page = PageFactory.GetPage(pageId, Language.CurrentLanguageId);
+            return page.PageUrl.ToString();
+        }
 
         #endregion
 

--- a/KalikoCMS.Mvc/Extensions/HtmlHelperExtensions.cs
+++ b/KalikoCMS.Mvc/Extensions/HtmlHelperExtensions.cs
@@ -26,6 +26,9 @@ namespace KalikoCMS.Mvc.Extensions {
     using System.Web.Mvc;
     using Core;
     using Core.Collections;
+    using KalikoCMS;
+    using KalikoCMS.Configuration;
+    using KalikoCMS.Core;
 
     public static class HtmlHelperExtensions {
         #region Breadcrumbs


### PR DESCRIPTION
As the URL's that come from the CMS are not routes, I find it easier to define two methods to help generate URL's to CMS pages so that I don't have to hard code them. The two methods posted help resolve this issue. Do we need to set up any examples of how to use these methods so that others are aware that they exist?